### PR TITLE
Add folder selection functionality to ContentView

### DIFF
--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -1,14 +1,34 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedFolder: URL?
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            Button(action: {
+                selectFolder()
+            }) {
+                Text("フォルダを選択")
+            }
+
+            if let folder = selectedFolder {
+                Text("選択されたフォルダ: \(folder.path)")
+                    .padding(.top, 10)
+            }
         }
         .padding()
+    }
+
+    func selectFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                selectedFolder = url
+            }
+        }
     }
 }
 

--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
             }
 
             if let folder = selectedFolder {
-                Text("選択されたフォルダ: \(folder.path)")
+                Text("フォルダが選択されました: \(folder.path)")
                     .padding(.top, 10)
             }
 
@@ -32,16 +32,18 @@ struct ContentView: View {
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.begin { response in
-            if response == .OK, let url = panel.url {
-                selectedFolder = url
-                errorMessage = nil
-            } else if response == .cancel {
-                selectedFolder = nil
-                errorMessage = "フォルダの選択がキャンセルされました。"
-            } else {
-                selectedFolder = nil
-                errorMessage = "不明なエラーが発生しました。"
+        DispatchQueue.main.async {
+            panel.begin { response in
+                if response == .OK, let url = panel.url {
+                    selectedFolder = url
+                    errorMessage = nil // Reset error message when a new folder is selected
+                } else if response == .cancel {
+                    selectedFolder = nil
+                    errorMessage = "フォルダの選択がキャンセルされました。"
+                } else {
+                    selectedFolder = nil
+                    errorMessage = "選択中に予期しないエラーが発生しました。再試行してください。"
+                }
             }
         }
     }

--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedFolder: URL?
+    @State private var errorMessage: String?
 
     var body: some View {
         VStack {
@@ -15,18 +16,32 @@ struct ContentView: View {
                 Text("選択されたフォルダ: \(folder.path)")
                     .padding(.top, 10)
             }
+
+            if let errorMessage = errorMessage {
+                Text("エラー: \(errorMessage)")
+                    .foregroundColor(.red)
+                    .padding(.top, 10)
+            }
         }
         .padding()
     }
 
     func selectFolder() {
         let panel = NSOpenPanel()
+        panel.directoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
         panel.begin { response in
             if response == .OK, let url = panel.url {
                 selectedFolder = url
+                errorMessage = nil
+            } else if response == .cancel {
+                selectedFolder = nil
+                errorMessage = "フォルダの選択がキャンセルされました。"
+            } else {
+                selectedFolder = nil
+                errorMessage = "不明なエラーが発生しました。"
             }
         }
     }


### PR DESCRIPTION
### **User description**
フォルダ選択ボタンを追加した


___

### **PR Type**
enhancement


___

### **Description**
- `ContentView`にフォルダ選択ボタンを追加しました。
- ユーザーが選択したフォルダのパスを表示する機能を実装しました。
- フォルダ選択のためのダイアログを表示するメソッドを追加しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContentView.swift</strong><dd><code>フォルダ選択機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RecursiveTextMerger/ContentView.swift

- フォルダ選択ボタンを追加
- 選択されたフォルダのパスを表示
- フォルダ選択機能を実装



</details>


  </td>
  <td><a href="https://github.com/75py/macos-recursive-text-merger/pull/3/files#diff-93fef627f301384caf42a8e75566bccba2aba5c8a69bdd192b073d5dbf7b88e5">+24/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

