### PR TITLE
Add folder contents fetching and display functionality

### DIFF
--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -61,9 +61,11 @@ struct ContentView: View {
         do {
             let fileManager = FileManager.default
             let files = try fileManager.contentsOfDirectory(atPath: url.path)
-            folderContents = files
+            DispatchQueue.main.async {
+                folderContents = files
+            }
         } catch {
-            errorMessage = "フォルダの内容を取得中にエラーが発生しました。"
+            errorMessage = "フォルダの内容を取得中にエラーが発生しました: \(error.localizedDescription)"
             folderContents = []
         }
     }

--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedFolder: URL?
+    @State private var folderContents: [String] = []
     @State private var errorMessage: String?
 
     var body: some View {
@@ -15,6 +16,13 @@ struct ContentView: View {
             if let folder = selectedFolder {
                 Text("フォルダが選択されました: \(folder.path)")
                     .padding(.top, 10)
+
+                if !folderContents.isEmpty {
+                    List(folderContents, id: \.self) { file in
+                        Text(file)
+                    }
+                    .padding(.top, 10)
+                }
             }
 
             if let errorMessage = errorMessage {
@@ -37,6 +45,7 @@ struct ContentView: View {
                 if response == .OK, let url = panel.url {
                     selectedFolder = url
                     errorMessage = nil // Reset error message when a new folder is selected
+                    fetchFolderContents(from: url)
                 } else if response == .cancel {
                     selectedFolder = nil
                     errorMessage = "フォルダの選択がキャンセルされました。"
@@ -45,6 +54,17 @@ struct ContentView: View {
                     errorMessage = "選択中に予期しないエラーが発生しました。再試行してください。"
                 }
             }
+        }
+    }
+    
+    func fetchFolderContents(from url: URL) {
+        do {
+            let fileManager = FileManager.default
+            let files = try fileManager.contentsOfDirectory(atPath: url.path)
+            folderContents = files
+        } catch {
+            errorMessage = "フォルダの内容を取得中にエラーが発生しました。"
+            folderContents = []
         }
     }
 }

--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -66,7 +66,9 @@ struct ContentView: View {
             }
         } catch {
             errorMessage = "フォルダの内容を取得中にエラーが発生しました: \(error.localizedDescription)"
-            folderContents = []
+            DispatchQueue.main.async {
+                folderContents = []
+            }
         }
     }
 }

--- a/RecursiveTextMerger/ContentView.swift
+++ b/RecursiveTextMerger/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedFolder: URL?
-    @State private var folderContents: [String] = []
+    @State private var folderContents: [URL] = []
     @State private var errorMessage: String?
 
     var body: some View {
@@ -19,7 +19,7 @@ struct ContentView: View {
 
                 if !folderContents.isEmpty {
                     List(folderContents, id: \.self) { file in
-                        Text(file)
+                        Text(file.absoluteString)
                     }
                     .padding(.top, 10)
                 }
@@ -60,13 +60,14 @@ struct ContentView: View {
     func fetchFolderContents(from url: URL) {
         do {
             let fileManager = FileManager.default
-            let files = try fileManager.contentsOfDirectory(atPath: url.path)
+            
+            let files = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
             DispatchQueue.main.async {
                 folderContents = files
             }
         } catch {
-            errorMessage = "フォルダの内容を取得中にエラーが発生しました: \(error.localizedDescription)"
             DispatchQueue.main.async {
+                errorMessage = "フォルダの内容を取得中にエラーが発生しました: \(error.localizedDescription)"
                 folderContents = []
             }
         }


### PR DESCRIPTION
### **User description**
aaa


___

### **PR Type**
Enhancement


___

### **Description**
- `folderContents` プロパティを追加し、選択したフォルダの内容を表示する機能を実装しました。
- フォルダが選択された際に、その内容をリスト形式で表示します。
- フォルダの内容を取得するための `fetchFolderContents` メソッドを追加しました。
- エラーメッセージの処理を改善し、ユーザーに明確なフィードバックを提供します。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContentView.swift</strong><dd><code>フォルダの内容取得と表示機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RecursiveTextMerger/ContentView.swift

<li><code>folderContents</code> プロパティを追加し、フォルダの内容を格納<br> <li> フォルダが選択された際に内容を表示するリストを追加<br> <li> フォルダの内容を取得する <code>fetchFolderContents</code> メソッドを実装<br> <li> エラーメッセージの処理を改善<br>


</details>


  </td>
  <td><a href="https://github.com/75py/macos-recursive-text-merger/pull/5/files#diff-93fef627f301384caf42a8e75566bccba2aba5c8a69bdd192b073d5dbf7b88e5">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

